### PR TITLE
fix(workflows): updated workflows for beta process

### DIFF
--- a/.github/workflows/beta-auto-merge.yaml
+++ b/.github/workflows/beta-auto-merge.yaml
@@ -69,32 +69,3 @@ jobs:
             fi
             echo "----------------------------"
         done
-
-    - name: check for changes
-      run: |
-        # get the latest tag
-        latestTag=$(git describe --tags $(git rev-list --tags --max-count=1))
-        echo "Latest tag found is: $latestTag"
-        echo "latestTag=$latestTag" >> "$GITHUB_ENV"
-
-        betaDiff=$(git log $latestTag..origin/beta --oneline)
-        echo "The diff between the latest tag and beta is $betaDiff"
-        if [[ -n $betaDiff ]]; then
-          echo "Diff found"
-          echo "isDiff=true" >> "$GITHUB_ENV"
-        else
-          echo "No diff found"
-          echo "isDiff=false" >> "$GITHUB_ENV"
-        fi
-
-    - name: Create new release release
-      if: env.isDiff == 'true'
-      run: |
-        # returns the current date in YYYY-MM-DD format
-        date=$(date +%F) 
-        echo "New tag is $date"
-
-        echo "Auto generated release notes will be compared to previous tag $latestTag"
-
-        # create the release
-        gh release create $date --latest --generate-notes --target=beta --notes-start-tag $latestTag

--- a/.github/workflows/beta-promote.yaml
+++ b/.github/workflows/beta-promote.yaml
@@ -1,9 +1,5 @@
 name: Promote Beta to Master
 on:
-  schedule:
-    # Every wednesdays, at 2h30/3h30 am(EST/EDT)
-    # running after the beta-auto-merge workflow to avoid overlap
-    - cron: "30 7 * * WED"
   pull_request:
     types:
       - 'opened'
@@ -11,26 +7,8 @@ on:
       - 'reopened'
 
 jobs:
-  get-bi-weekly-schedule:
-    runs-on: ubuntu-latest
-    outputs:
-      biweekly: ${{ steps.get-biweekly-modulo.outputs.biweekly }}
-    steps:
-      # Step to determine the week number in the year, to run this job bi-weekly
-      # cron schedule doesn't support "every 2 weeks" scenarios.
-      # runs on alternating weeks from the beta-auto-merge.yaml workflow
-      - name: Get bi-weekly week number value
-        id: get-biweekly-modulo
-        run: |
-          numWeek=$(date +%U)
-          echo "biweekly=$((numWeek % 2))" >> $GITHUB_OUTPUT
-          echo "This is week #$numWeek, biweekly modulo is at $((numWeek % 2))."
-          echo "Job will run on value==0"
-
   create-pr-beta-to-prod:
     runs-on: ubuntu-latest
-    needs: get-bi-weekly-schedule
-    # if: ${{ needs.get-bi-weekly-schedule.outputs.biweekly == 0 }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:    

--- a/.github/workflows/beta-promote.yaml
+++ b/.github/workflows/beta-promote.yaml
@@ -1,14 +1,30 @@
 name: Promote Beta to Master
 on:
-  pull_request:
-    types:
-      - 'opened'
-      - 'synchronize'
-      - 'reopened'
+  schedule:
+    # Every wednesdays, at 2h30/3h30 am(EST/EDT)
+    # running after the beta-auto-merge workflow to avoid overlap
+    - cron: "30 7 * * WED"
 
 jobs:
+  get-bi-weekly-schedule:
+    runs-on: ubuntu-latest
+    outputs:
+      biweekly: ${{ steps.get-biweekly-modulo.outputs.biweekly }}
+    steps:
+      # Step to determine the week number in the year, to run this job bi-weekly
+      # cron schedule doesn't support "every 2 weeks" scenarios.
+      # runs on alternating weeks from the beta-auto-merge.yaml workflow
+      - name: Get bi-weekly week number value
+        id: get-biweekly-modulo
+        run: |
+          numWeek=$(date +%U)
+          echo "biweekly=$((numWeek % 2))" >> $GITHUB_OUTPUT
+          echo "This is week #$numWeek, biweekly modulo is at $((numWeek % 2))."
+          echo "Job will run on value==0"
   create-pr-beta-to-prod:
     runs-on: ubuntu-latest
+    needs: get-bi-weekly-schedule
+    if: ${{ needs.get-bi-weekly-schedule.outputs.biweekly == 0 }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:    
@@ -19,5 +35,5 @@ jobs:
     
     - name: Create PR for beta to master
       run: |
-        gh pr create --base master --title "chore: Promote beta to master" \
+        gh pr create --base master --title "chore: promote beta to master" \
           --body "Automatically generated PR to merge beta to master"

--- a/.github/workflows/beta-promote.yaml
+++ b/.github/workflows/beta-promote.yaml
@@ -21,25 +21,3 @@ jobs:
       run: |
         gh pr create --base master --title "chore: Promote beta to master" \
           --body "Automatically generated PR to merge beta to master"
-    # required step for the merge command to work
-    # - name: Set Git config
-    #   run: |
-    #     git config --local user.email "actions@github.com"
-    #     git config --local user.name "GitHub Actions"
-    
-    # - name: "Merge Beta to Master"
-    #   run: git merge origin/beta --verbose --ff --no-edit
-
-    # - name: "Push updated master to remote"
-    #   run: |
-    #     if [[ -z "$(git status --porcelain)" ]]; then
-    #       echo "Clean working tree. Pushing to master"
-    #       git push
-    #     else
-    #       echo "Dirty working tree. Not pushing to master"
-    #       git status
-
-    #       # fail the job
-    #       exit 1
-    #     fi
-

--- a/.github/workflows/beta-promote.yaml
+++ b/.github/workflows/beta-promote.yaml
@@ -4,6 +4,11 @@ on:
     # Every wednesdays, at 2h30/3h30 am(EST/EDT)
     # running after the beta-auto-merge workflow to avoid overlap
     - cron: "30 7 * * WED"
+  pull_request:
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
 
 jobs:
   get-bi-weekly-schedule:
@@ -22,37 +27,42 @@ jobs:
           echo "This is week #$numWeek, biweekly modulo is at $((numWeek % 2))."
           echo "Job will run on value==0"
 
-  promote-beta-to-prod:
+  create-pr-beta-to-prod:
     runs-on: ubuntu-latest
     needs: get-bi-weekly-schedule
-    if: ${{ needs.get-bi-weekly-schedule.outputs.biweekly == 0 }}
+    # if: ${{ needs.get-bi-weekly-schedule.outputs.biweekly == 0 }}
     env:
       GH_TOKEN: ${{ github.token }}
     steps:    
-    - name: "Checkout master"
+    - name: "Checkout beta"
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
-        ref: master
+        # fetch-depth: 0
+        ref: beta
     
+    - name: Create PR for beta to master
+      run: |
+        gh pr create --base master --title "chore: Promote beta to master" \
+          --body "Automatically generated PR to merge beta to master"
     # required step for the merge command to work
-    - name: Set Git config
-      run: |
-        git config --local user.email "actions@github.com"
-        git config --local user.name "GitHub Actions"
+    # - name: Set Git config
+    #   run: |
+    #     git config --local user.email "actions@github.com"
+    #     git config --local user.name "GitHub Actions"
     
-    - name: "Merge Beta to Master"
-      run: git merge origin/beta --verbose --ff --no-edit
+    # - name: "Merge Beta to Master"
+    #   run: git merge origin/beta --verbose --ff --no-edit
 
-    - name: "Push updated master to remote"
-      run: |
-        if [[ -z "$(git status --porcelain)" ]]; then
-          echo "Clean working tree. Pushing to master"
-          git push
-        else
-          echo "Dirty working tree. Not pushing to master"
-          git status
+    # - name: "Push updated master to remote"
+    #   run: |
+    #     if [[ -z "$(git status --porcelain)" ]]; then
+    #       echo "Clean working tree. Pushing to master"
+    #       git push
+    #     else
+    #       echo "Dirty working tree. Not pushing to master"
+    #       git status
 
-          # fail the job
-          exit 1
-        fi
+    #       # fail the job
+    #       exit 1
+    #     fi
+

--- a/.github/workflows/beta-promote.yaml
+++ b/.github/workflows/beta-promote.yaml
@@ -15,7 +15,6 @@ jobs:
     - name: "Checkout beta"
       uses: actions/checkout@v4
       with:
-        # fetch-depth: 0
         ref: beta
     
     - name: Create PR for beta to master

--- a/.github/workflows/beta-release.yaml
+++ b/.github/workflows/beta-release.yaml
@@ -1,0 +1,46 @@
+name: Create automatic release for master
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+
+jobs:
+  create_release_for_master:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:    
+    - name: "Checkout master"
+      uses: actions/checkout@v4
+    
+    - name: check for changes
+      run: |
+        # get the latest tag
+        latestTag=$(git describe --tags $(git rev-list --tags --max-count=1))
+        echo "Latest tag found is: $latestTag"
+        echo "latestTag=$latestTag" >> "$GITHUB_ENV"
+
+        masterDiff=$(git log $latestTag..origin/master --oneline)
+        echo "The diff between the latest tag and master is $masterDiff"
+        if [[ -n $masterDiff ]]; then
+          echo "Diff found"
+          echo "isDiff=true" >> "$GITHUB_ENV"
+        else
+          echo "No diff found"
+          echo "isDiff=false" >> "$GITHUB_ENV"
+        fi
+
+    - name: Create new release release
+      if: env.isDiff == 'true'
+      run: |
+        # returns the current date in YYYY-MM-DD format
+        date=$(date +%F) 
+        echo "New tag is $date"
+
+        echo "Auto generated release notes will be compared to previous tag $latestTag"
+
+        # create the release
+        gh release create $date --latest --generate-notes --target=master --notes-start-tag $latestTag


### PR DESCRIPTION
# Description

for https://jirab.statcan.ca/browse/ZONE-130 

# Tests / Quality Checks


# Beta Process
- [ ] Should this branch target "beta"?

## Are there breaking changes?
Ask yourself the next question;
- [ ] Do we want to maintain the previous image from which we had to do breaking changes from?

If no, then carry on. If yes, there is a breaking change and we **want to maintain the previous image** do the following
- [ ] Create a new branch for the current version (ex v1) based off the current master/main branch
- [ ]  Increment the tag in the CI for pushes to master/main (v1 to v2)
- [ ] Change the CI that on pushes to the newly created "v1" branch (the name of the newly created branch we want to maintain is) it will push to the ACR. 
## Automated Testing/build and deployment
- [ ] Does the image pass CI successfully (build, pass vulnerability scan, and pass automated test suite)?
- [ ] If new features are added (new image, new binary, etc), have new automated tests been added to cover these?
- [ ] If new features are added that require in-cluster testing (e.g. a new feature that needs to interact with kubernetes), have you added the `auto-deploy` tag to the PR before pushing in order to build and push the image to ACR so you can test it in cluster as a custom image?

## JupyterLab extensions

- [ ] Are all extensions "enabled" (`jupyter labextension list` from inside the notebook)?

## VS Code tests

- [ ] Does VS Code open?
- [ ] Can you install extensions?

## Code review

- [ ] Have you added the `auto-deploy` tag to your PR before your most recent push to this repo?  This causes CI to build the image and push to our ACR, letting reviewers access the built image without having to create it themselves
- [ ] Have you chosen a reviewer, attached them as a reviewer to this PR, and messaged them with the SHA-pinned image name for the final image to test on the **dev cluster** (e.g. `k8scc01covidacrdev.azurecr.io/jupyterlab-cpu:746d058e2f37e004da5ca483d121bfb9e0545f2b`)?
